### PR TITLE
glob all the js files in subdirectories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,8 @@ module.exports = function compile ({
   const entries = []
 
   // Add main entry glob
-  entries.push(resolve(src, '**/*.js'))
+  entries.push(resolve(src, '*.js'))
+  entries.push(resolve(src, 'scripts/*.js'))
 
   // Add autoReload in dev
   if (autoReload && ['chrome', 'opera'].includes(vendor)) {

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ module.exports = function compile ({
   const entries = []
 
   // Add main entry glob
-  entries.push(resolve(src, '*.js'))
+  entries.push(resolve(src, '**/*.js'))
 
   // Add autoReload in dev
   if (autoReload && ['chrome', 'opera'].includes(vendor)) {


### PR DESCRIPTION
The original glob didn't capture any of the files in the `scripts` subdirectory.

This should take care of the issue addressed in #6 